### PR TITLE
**Changed:** VSIX Manifest file to allow Extension to run in Visual Studio 2019.

### DIFF
--- a/quicktype-vs/source.extension.vsixmanifest
+++ b/quicktype-vs/source.extension.vsixmanifest
@@ -8,14 +8,14 @@
         <Tags>c#, c++, json, typescript</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0]" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
         <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to work with Visual Studio 2019.

Original issue: [Issue #7 ](https://github.com/quicktype/quicktype-vs/issues/7)

This involved some minor updates to the Manifest file to allow later Versions of Visual Studio and also updated the Version Range for the 'Microsoft.VisualStudio.Component.CoreEditor' prerequisite.

Apologies for the delay, I just wish I had discovered this Extension sooner.
Thank you very much for the work involved in creating and improving this Extension, I hope to use it plenty in future!

Hope this helps!