### PR TITLE
**Updated:** VSIX Manifest file to correctly specify range for 'Microsoft.VisualStudio.Component.CoreEditor'.

### DIFF
--- a/quicktype-vs/source.extension.vsixmanifest
+++ b/quicktype-vs/source.extension.vsixmanifest
@@ -15,7 +15,7 @@
         <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Hi all!

I've just raised another PR to correct a formatting error I had introduced.
[Pull Request 8 - Changed VSIX Manifest file to allow Extension to run in Visual Studio 2019. ](https://github.com/quicktype/quicktype-vs/pull/8)

The '**Microsoft.VisualStudio.Component.CoreEditor**' specifies a range for permitted versions.

So where I had [15.0,16.0,17.0) I should have actually specified [15.0,17.0).

Apologies for any inconvenience caused!